### PR TITLE
Fix rtd build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip absl-py opt_einsum numpy scipy pytest-xdist pytest-benchmark
   - pip install jaxlib jax
+  - pip install tensorflow tensorflow-datasets
   - pip install -v .
 script:
   # make default temporary dir for absl tests

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,8 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 autosummary_generate = True
 
+master_doc = 'index'
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/notebooks/flax_intro.ipynb
+++ b/docs/notebooks/flax_intro.ipynb
@@ -453,7 +453,8 @@
       "source": [
         "input_spec = [(1, 2)] # the input specification is a list of shape tuples\n",
         "out_spec, params = SimpleRNN.init_by_shape(random.PRNGKey(0), input_spec)\n",
-        "print('out_spec:', out_spec)\n",
+        "# TODO: uncomment this line  once __repr__ is fixed in jax\n",
+        "# print('out_spec:', out_spec)\n",
         "jax.tree_map(np.shape, params)"
       ]
     },

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,2 @@
+tensorflow
+tensorflow-datasets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 numpy
 jaxlib
 jax
-# tensorflow is needed for tensorflow-datasets
-tensorflow
-tensorflow-datasets
 msgpack

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,6 @@ install_requires = [
     "numpy",
     "jaxlib",
     "jax",
-    "tensorflow",  # Only needed for tensorflow-datasets
-    "tensorflow-datasets",
     "matplotlib",  # only needed for tensorboard export
     "dataclasses",  # will only install on py3.6
     "msgpack",


### PR DESCRIPTION
ReadTheDocs will fail with an OOM because TensorFlow is too large a dependency.
I think we shouldn't force users to install this anyway because flax does not actually need TF.

This PR also fixes a small bug in the notebook and adds a missing line of configuration that RTD needs to build