### PR TITLE
Minor appearance improvements for API reference docs

### DIFF
--- a/docs/flax.nn.rst
+++ b/docs/flax.nn.rst
@@ -6,11 +6,14 @@ flax.nn package
 .. automodule:: flax.nn
 
 
-Module abstraction
+Core: Module abstraction
 ------------------------
 
 .. autoclass:: Module
    :members: create, create_by_shape, init, init_by_shape, partial, shared, apply, param, get_param, state, is_stateful, is_initializing
+
+Core: Additional
+------------------------
 
 .. autosummary::
   :toctree: _autosummary

--- a/docs/flax.serialization.rst
+++ b/docs/flax.serialization.rst
@@ -16,7 +16,7 @@ State dicts
 .. autofunction:: register_serialization_state
 
 
-Message pack
+Serialization with MessagePack
 ------------------------
 
 .. autofunction:: msgpack_serialize

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,11 @@ Welcome to Flax's documentation!
    contributing
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
    :caption: API reference:
 
-   flax
+   flax.nn
+   flax.optim
+   flax.serialization
+   flax.struct
+   flax.jax_utils


### PR DESCRIPTION
This makes the front docs page more directly link to the different parts of Flax, and shows that it's very straightforward. Also changed headings in the flax.nn documentation to make the core parts seem different than the specific layers that we have.