### PR TITLE
Fix mime type of description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     version=version,
     description="Flax: A neural network library for JAX designed for flexibility",
     long_description="\n\n".join([README]),
+    long_description_content_type='text/markdown',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
readme had the wrong mime type which causes a failure when building python wheels